### PR TITLE
Add event date to page title

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 	<head>
-		<title>HackKean</title>
+		<title>HackKean | May 7-8</title>
 		<meta charset="utf-8" />
 		<meta name="keywords" content="Hackathon,New Jersey,Union,Kean,Kean University">
 		<meta name="description" content="A Hackathon for students and by students, held at  at Kean University in Union, NJ">


### PR DESCRIPTION
You can do everyone a HUGE favor by putting dates in your homepage < title > tag. There are a handful of times where people end up visiting hackathon sites just to double-check when an event is happening.

Feel free to implement this however you want, my PR is just a suggestion.

Here is how your page currently looks:

![image](https://cloud.githubusercontent.com/assets/607807/14770860/87965f0c-0a48-11e6-934d-732c2c8a0f77.png)

![image](https://cloud.githubusercontent.com/assets/607807/14770871/b841469e-0a48-11e6-80b2-ee21c09413b4.png)
